### PR TITLE
fix(vite): improve server config for HMR and cloud environments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,4 +19,12 @@ export default defineConfig({
       plugins: [NodeGlobalsPolyfillPlugin({ process: true, buffer: true })],
     },
   },
+  server: {
+    host: '0.0.0.0',     
+    port: 5173,          
+    hmr: {
+      clientPort: 443,   
+    },
+    allowedHosts: true, 
+  },
 });


### PR DESCRIPTION
Update vite.config.ts:
- Set host to '0.0.0.0' (allows access from external devices or cloud URLs)
- Fix HMR client connection with clientPort 443 (needed for HTTPS environments like Replit)
- Allow all hosts (prevents blocking requests from custom domains)